### PR TITLE
Remove test case super calls

### DIFF
--- a/de.simonscholz.codemodify/src/de/simonscholz/junit4converter/JUnit4Converter.java
+++ b/de.simonscholz.codemodify/src/de/simonscholz/junit4converter/JUnit4Converter.java
@@ -137,11 +137,14 @@ public class JUnit4Converter implements ICompilationUnitModifier {
 	protected void removeSuperCall(ASTRewrite rewriter,
 			MethodDeclaration methodDeclaration) {
 		List statements = methodDeclaration.getBody().statements();
-		if (statements.size() >= 1) {
-			Object object = statements.get(0);
+		for (Object object : statements) {
 			if (object instanceof Statement) {
 				Statement superCall = (Statement) object;
-				if (superCall.toString().startsWith("super")) {
+				String superCallAsString = superCall.toString().trim();
+				String toBeReplacedSuperCall = "super."
+						+ methodDeclaration.getName().getFullyQualifiedName()
+						+ "();";
+				if (superCallAsString.equals(toBeReplacedSuperCall)) {
 					rewriter.remove(superCall, null);
 				}
 			}


### PR DESCRIPTION
Hi Simon,
First, thanks for your work. It helped us to convert our existing tests.
I noticed a small problem when converting our tests.
In our setup/teardown methods we usually left the super call to TestCase.

So I extended your logic, by removing these two calls, which are now not necessary anymore.

If you have any improvements let me know.
Thanks!

Some pictures of the described problem for your understanding (sometimes better than words).
Before conversion:
![before](https://cloud.githubusercontent.com/assets/7139697/5245274/c853b386-7959-11e4-87a2-df48f1f90dc2.png)
After conversion:
![after](https://cloud.githubusercontent.com/assets/7139697/5245276/caa3f826-7959-11e4-9f8f-8439762bb158.png)

These screenshots are made before my changes.
