### PR TITLE
Only annotate public testmethods with @Test

### DIFF
--- a/de.simonscholz.codemodify/src/de/simonscholz/junit4converter/JUnit4Converter.java
+++ b/de.simonscholz.codemodify/src/de/simonscholz/junit4converter/JUnit4Converter.java
@@ -106,7 +106,8 @@ public class JUnit4Converter implements ICompilationUnitModifier {
 			methodDeclaration.accept(new StaticAssertImportVisitor(
 					importRewrite));
 
-			if (fullyQualifiedName.toLowerCase().startsWith(TEST_METHOD_PREFIX)) {
+			if (fullyQualifiedName.toLowerCase().startsWith(TEST_METHOD_PREFIX)
+					&& isPublicMethod(methodDeclaration)) {
 				createMarkerAnnotation(ast, rewriter, methodDeclaration,
 						TEST_ANNOTATION_NAME);
 				importRewrite.addImport(TEST_ANNOTATION_QUALIFIED_NAME);
@@ -129,6 +130,18 @@ public class JUnit4Converter implements ICompilationUnitModifier {
 				modifiedDocument = true;
 			}
 		}
+	}
+
+	protected boolean isPublicMethod(MethodDeclaration methodDeclaration) {
+		List modifiers = methodDeclaration.modifiers();
+		for (Object object : modifiers) {
+			if (object instanceof Modifier) {
+				Modifier modifier = (Modifier) object;
+				return ModifierKeyword.PUBLIC_KEYWORD.equals(modifier
+						.getKeyword());
+			}
+		}
+		return false;
 	}
 
 	protected void removeTestCaseSuperclass(ASTRewrite rewriter,


### PR DESCRIPTION
We had some issues with private methods which were annotated with @Test.
Probably this was ignored cause private testMethods fail. In our case we had methods like:
private void testSomethingWithString(String myString), which a conversion shouldnt take place.

I fixed it by limitating the annotation @Test only to public methods
