### PR TITLE
Update target platform

### DIFF
--- a/de.simonscholz.codemodify.target/de.simonscholz.codemodify.target.target
+++ b/de.simonscholz.codemodify.target/de.simonscholz.codemodify.target.target
@@ -2,8 +2,8 @@
 <?pde version="3.8"?><target name="eclipse47" sequenceNumber="14">
 <locations>
 <location includeAllPlatforms="false" includeConfigurePhase="true" includeMode="planner" includeSource="true" type="InstallableUnit">
-<unit id="org.eclipse.sdk.ide" version="4.7.0.I20170126-1030"/>
-<repository location="http://download.eclipse.org/eclipse/updates/4.7milestones"/>
+<unit id="org.eclipse.sdk.ide" version="4.7.0.I20170612-0950"/>
+<repository location="http://download.eclipse.org/eclipse/updates/4.7"/>
 </location>
 </locations>
 </target>


### PR DESCRIPTION
I wanted to run:

```
 mvn verify
```

at the root of this repo, but I got:

```
[ERROR] Failed to resolve target definition /___/codemodify/de.simonscholz.codemodify.target/de.simonscholz.codemodify.target.target: Failed to load p2 metadata repository from location http://download.eclipse.org/eclipse/updates/4.7milestones: No repository found at http://download.eclipse.org/eclipse/updates/4.7milestones. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MavenExecutionException
```

This PR is a minimal change. I took the update site and the version that was as close as possible of the existing in the current pom.

There is big chances that this tools works also with newer versions, but I did not investigate it.